### PR TITLE
Feature: Convert PDF certificates to JPEG on upload using PDF.js

### DIFF
--- a/proofi/components/dashboard/CertificateFormModal.tsx
+++ b/proofi/components/dashboard/CertificateFormModal.tsx
@@ -5,6 +5,7 @@ import type { Certificate } from "@prisma/client";
 import { DOMAINS, MAX_FILE_SIZE_BYTES, ACCEPTED_FILE_TYPES, ACCEPTED_FILE_ACCEPT } from "@/lib/constants";
 import { uploadCertificateImage } from "@/lib/utils/storage";
 import { compressImage } from "@/lib/compressImage";
+import { pdfToJpeg } from "@/lib/utils/pdfToImage";
 
 interface Props {
   initialData: Certificate | null;
@@ -56,6 +57,7 @@ export default function CertificateFormModal({ initialData, onSave, onClose, aut
   );
   const [loading, setLoading] = useState(false);
   const [compressing, setCompressing] = useState(false);
+  const [converting, setConverting] = useState(false);
   const [extracting, setExtracting] = useState(false);
   const [extractNotice, setExtractNotice] = useState<ExtractNotice>(null);
   const [verifying, setVerifying] = useState(false);
@@ -178,7 +180,7 @@ export default function CertificateFormModal({ initialData, onSave, onClose, aut
     }
   };
 
-  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
     if (!ACCEPTED_FILE_TYPES.includes(file.type)) {
@@ -189,24 +191,39 @@ export default function CertificateFormModal({ initialData, onSave, onClose, aut
       setError("File must be 5MB or smaller.");
       return;
     }
-    setImageFile(file);
+
     setError(null);
     setExtractNotice(null);
+    setVerifyResult(null);
+
     if (file.type === "application/pdf") {
+      // Convert PDF page 1 → JPEG so the preview and upload are always an image
+      setConverting(true);
       setImagePreview(null);
-      setPdfPreviewUrl(URL.createObjectURL(file));
-      setIsPdf(true);
+      setIsPdf(false);
+      try {
+        const jpeg = await pdfToJpeg(file);
+        setImageFile(jpeg);
+        setImagePreview(URL.createObjectURL(jpeg));
+        if (autoFillEnabled) runExtraction(jpeg);
+        if (aiVerificationEnabled) runVerification(jpeg);
+      } catch (err) {
+        console.error("[pdf-convert]", err);
+        // Fallback: keep the original PDF if conversion fails
+        setImageFile(file);
+        setIsPdf(true);
+        setPdfPreviewUrl(URL.createObjectURL(file));
+        if (autoFillEnabled) runExtraction(file);
+        if (aiVerificationEnabled) runVerification(file);
+      } finally {
+        setConverting(false);
+      }
     } else {
+      setImageFile(file);
       setImagePreview(URL.createObjectURL(file));
       setIsPdf(false);
-    }
-    setVerifyResult(null);
-    // Trigger extraction only when the feature is enabled
-    if (autoFillEnabled) {
-      runExtraction(file);
-    }
-    if (aiVerificationEnabled) {
-      runVerification(file);
+      if (autoFillEnabled) runExtraction(file);
+      if (aiVerificationEnabled) runVerification(file);
     }
   };
 
@@ -222,7 +239,7 @@ export default function CertificateFormModal({ initialData, onSave, onClose, aut
   };
 
   const hasFile = !!imageFile || !!existingFileUrl;
-  const isDisabled = loading || extracting;
+  const isDisabled = loading || extracting || converting;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -368,7 +385,16 @@ export default function CertificateFormModal({ initialData, onSave, onClose, aut
               <span className="ml-1 font-normal text-slate-400 dark:text-white/25">(Image or PDF, max 5MB)</span>
             </label>
 
-            {hasFile ? (
+            {converting && (
+              <div className="h-32 sm:h-40 rounded-xl flex flex-col items-center justify-center gap-2 text-slate-400 dark:text-white/40" style={{ border: "1px solid var(--border)", background: "var(--surface-alt)" }}>
+                <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                <p className="text-xs font-medium">Converting PDF…</p>
+              </div>
+            )}
+            {!converting && hasFile ? (
               <div className="relative rounded-xl overflow-hidden" style={{ border: "1px solid var(--border)" }}>
                 {imagePreview && (
                   <div className="h-32 sm:h-40">
@@ -410,16 +436,18 @@ export default function CertificateFormModal({ initialData, onSave, onClose, aut
                 </div>
               </div>
             ) : (
-              <button type="button" onClick={() => fileRef.current?.click()} disabled={isDisabled}
-                className="w-full h-28 border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-2 transition-all border-black/[0.12] hover:border-violet-500/50 text-slate-400 hover:text-slate-600 dark:border-white/15 dark:hover:border-violet-500/50 dark:text-white/30 dark:hover:text-white/60 disabled:opacity-40 disabled:cursor-not-allowed">
-                <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
-                </svg>
-                <div className="text-center">
-                  <p className="text-xs font-semibold">Click to upload</p>
-                  <p className="text-xs mt-0.5 text-slate-300 dark:text-white/20">JPG, PNG, WebP, or PDF</p>
-                </div>
-              </button>
+              !converting && (
+                <button type="button" onClick={() => fileRef.current?.click()} disabled={isDisabled}
+                  className="w-full h-28 border-2 border-dashed rounded-xl flex flex-col items-center justify-center gap-2 transition-all border-black/[0.12] hover:border-violet-500/50 text-slate-400 hover:text-slate-600 dark:border-white/15 dark:hover:border-violet-500/50 dark:text-white/30 dark:hover:text-white/60 disabled:opacity-40 disabled:cursor-not-allowed">
+                  <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
+                  </svg>
+                  <div className="text-center">
+                    <p className="text-xs font-semibold">Click to upload</p>
+                    <p className="text-xs mt-0.5 text-slate-300 dark:text-white/20">JPG, PNG, WebP, or PDF</p>
+                  </div>
+                </button>
+              )
             )}
             <input ref={fileRef} type="file" accept={ACCEPTED_FILE_ACCEPT} className="hidden" onChange={handleFileSelect} />
 

--- a/proofi/lib/utils/pdfToImage.ts
+++ b/proofi/lib/utils/pdfToImage.ts
@@ -1,0 +1,49 @@
+/**
+ * Renders page 1 of a PDF file to a JPEG using PDF.js.
+ * Runs entirely in the browser — no server required.
+ * Scale 2× gives a sharp render suitable for both thumbnails and lightbox.
+ */
+export async function pdfToJpeg(file: File): Promise<File> {
+  const pdfjsLib = await import("pdfjs-dist");
+
+  // Webpack resolves this URL pattern and emits the worker as a separate chunk
+  pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
+    "pdfjs-dist/build/pdf.worker.min.mjs",
+    import.meta.url
+  ).href;
+
+  const arrayBuffer = await file.arrayBuffer();
+  const loadingTask = pdfjsLib.getDocument({ data: new Uint8Array(arrayBuffer) });
+  const pdf = await loadingTask.promise;
+
+  const page = await pdf.getPage(1);
+
+  // 2× scale → sharp image even on retina displays
+  const viewport = page.getViewport({ scale: 2 });
+
+  const canvas = document.createElement("canvas");
+  canvas.width = viewport.width;
+  canvas.height = viewport.height;
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Could not get canvas context");
+
+  await page.render({ canvasContext: ctx, viewport, canvas }).promise;
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) { reject(new Error("Canvas export failed")); return; }
+        resolve(
+          new File(
+            [blob],
+            file.name.replace(/\.pdf$/i, ".jpg"),
+            { type: "image/jpeg" }
+          )
+        );
+      },
+      "image/jpeg",
+      0.92
+    );
+  });
+}

--- a/proofi/package-lock.json
+++ b/proofi/package-lock.json
@@ -15,6 +15,7 @@
         "browser-image-compression": "^2.0.2",
         "next": "16.2.1",
         "nodemailer": "^8.0.4",
+        "pdfjs-dist": "^5.6.205",
         "prisma": "^6.19.2",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -1037,6 +1038,256 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+      "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-x64": "0.1.97",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+      "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+      "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+      "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+      "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+      "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+      "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+      "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
+      "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+      "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -5510,6 +5761,13 @@
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -5791,6 +6049,19 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.6.205",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.96",
+        "node-readable-to-web-readable-stream": "^0.4.2"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",

--- a/proofi/package.json
+++ b/proofi/package.json
@@ -16,6 +16,7 @@
     "browser-image-compression": "^2.0.2",
     "next": "16.2.1",
     "nodemailer": "^8.0.4",
+    "pdfjs-dist": "^5.6.205",
     "prisma": "^6.19.2",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
- Installs pdfjs-dist v5 for client-side PDF rendering
- New lib/utils/pdfToImage.ts renders PDF page 1 to a 2× JPEG via canvas
- CertificateFormModal converts PDFs before upload — stored as JPEG instead of PDF
- Preview, AI auto-fill, and AI verification all receive the converted image
- "Converting PDF…" spinner shown during conversion; form disabled until complete
- Falls back to original PDF if conversion fails